### PR TITLE
feat: Support system proxy via ALL_PROXY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
+	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.46.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.51.0
@@ -86,7 +87,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/internal/tg/client.go
+++ b/internal/tg/client.go
@@ -115,10 +115,16 @@ func (c *GotdClient) Connect(ctx context.Context, cfg *config.Config, af *AuthFl
 		}
 	}()
 
+	dialer := proxy.FromEnvironment()
+	if dialer != proxy.Direct {
+		c.log.Info("using system proxy from ALL_PROXY")
+	}
 	resolver := dcs.Plain(dcs.PlainOptions{
 		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			d := proxy.FromEnvironment()
-			return d.(proxy.ContextDialer).DialContext(ctx, network, addr)
+			if cd, ok := dialer.(proxy.ContextDialer); ok {
+				return cd.DialContext(ctx, network, addr)
+			}
+			return dialer.Dial(network, addr)
 		},
 	})
 

--- a/internal/tg/client.go
+++ b/internal/tg/client.go
@@ -2,12 +2,15 @@ package tg
 
 import (
 	"context"
+	"net"
 	"sync"
 
 	"go.uber.org/zap"
+	"golang.org/x/net/proxy"
 
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/telegram/auth"
+	"github.com/gotd/td/telegram/dcs"
 	"github.com/gotd/td/telegram/updates"
 	"github.com/gotd/td/tg"
 
@@ -112,9 +115,17 @@ func (c *GotdClient) Connect(ctx context.Context, cfg *config.Config, af *AuthFl
 		}
 	}()
 
+	resolver := dcs.Plain(dcs.PlainOptions{
+		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d := proxy.FromEnvironment()
+			return d.(proxy.ContextDialer).DialContext(ctx, network, addr)
+		},
+	})
+
 	tc := telegram.NewClient(cfg.Telegram.APIID, cfg.Telegram.APIHash, telegram.Options{
 		UpdateHandler:  hook,
 		SessionStorage: sess,
+		Resolver:       resolver,
 		Logger:         c.log,
 		// OnDead marks MTProto connection death (and the reconnect that follows)
 		// so a long-idle update stall (#119) can be correlated with connection


### PR DESCRIPTION
## Summary
- Use `golang.org/x/net/proxy.FromEnvironment()` as the dial function for gotd's DC resolver
- Automatically picks up `ALL_PROXY` / `all_proxy` env var (SOCKS5) with no config changes needed
- Falls back to direct connection when no proxy is set

## Usage
```
ALL_PROXY=socks5://127.0.0.1:1080 tele
```

## Test plan
- [ ] Run without proxy env — connects directly as before
- [ ] Set `ALL_PROXY=socks5://...` — traffic goes through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)