### PR TITLE
feat: add Nix flake for reproducible builds and dev shell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,41 @@
+name: Nix
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/nix.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/nix.yml"
+  workflow_dispatch:
+
+jobs:
+  flake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: flake check
+        run: nix flake check --print-build-logs
+
+      - name: build
+        run: nix build .#default --print-build-logs
+
+      - name: smoke test
+        run: ./result/bin/tele -version

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/spec.md
 
 # Dev build
 /tele
+/result
 
 # GoReleaser output
 /dist/

--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ go build \
   -o tele ./cmd/tele/
 ```
 
+If you're touching the flake and change `go.mod`/`go.sum`, `vendorHash` in `flake.nix`
+needs regenerating too: run `nix build`, then copy the "got: sha256-..." hash it
+reports into `flake.nix`.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -179,6 +179,45 @@ A plain console (cmd.exe / classic conhost) falls back to ANSI block-art photos.
 > Prefer a packaged install? A `.zip` containing `tele.exe`
 > (`tele_windows_amd64.zip`) is attached to every [release](https://github.com/sorokin-vladimir/tele/releases/latest).
 
+### Nix / NixOS
+
+`tele` ships a flake. Try it without installing anything:
+
+```sh
+nix run github:sorokin-vladimir/tele
+```
+
+Or install it into your profile:
+
+```sh
+nix profile install github:sorokin-vladimir/tele
+```
+
+To pull it in as an input of your own flake (e.g. a NixOS configuration):
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    tele = {
+      url = "github:sorokin-vladimir/tele";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+}
+```
+
+Then, in your configuration:
+
+```nix
+environment.systemPackages = [
+  inputs.tele.packages.${pkgs.system}.default
+];
+```
+
+A `nix develop` shell is also available in the repo for local development (go,
+golangci-lint, lefthook).
+
 ---
 
 ## First launch

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
-        version = "1.8.0";
+        # Derived from the checked-out commit rather than hardcoded, so it
+        # can't drift from what's actually built (see PR review discussion).
+        version = self.shortRev or self.dirtyShortRev or "unknown";
       in
       {
         packages.default = pkgs.buildGoModule {
@@ -25,6 +27,8 @@
 
           src = ./.;
 
+          # Must be regenerated whenever go.mod/go.sum changes: run `nix build`,
+          # copy the "got: sha256-..." hash it reports, and paste it here.
           vendorHash = "sha256-tZkIsry/MyILMb2USafVmzBfTbqeNQNZ/QtRryGCHgQ=";
 
           subPackages = [ "cmd/tele" ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "tele — a terminal-native Telegram client built for keyboard-driven workflows";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        version = "1.8.0";
+      in
+      {
+        packages.default = pkgs.buildGoModule {
+          pname = "tele";
+          inherit version;
+
+          src = ./.;
+
+          vendorHash = "sha256-tZkIsry/MyILMb2USafVmzBfTbqeNQNZ/QtRryGCHgQ=";
+
+          subPackages = [ "cmd/tele" ];
+
+          env.CGO_ENABLED = "0";
+
+          # main.buildAPIID / main.buildAPIHash / main.appName are release-time
+          # secrets/channel flags injected by .goreleaser.yaml — deliberately
+          # left unset here. Users supply real Telegram credentials via
+          # config.yml (see config.yml.example), which main.go already
+          # supports as a fallback.
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${version}"
+          ];
+
+          doCheck = true;
+
+          meta = {
+            description = "A terminal-native Telegram client built for keyboard-driven workflows";
+            homepage = "https://github.com/sorokin-vladimir/tele";
+            license = pkgs.lib.licenses.gpl3Only;
+            mainProgram = "tele";
+            platforms = pkgs.lib.platforms.unix;
+          };
+        };
+
+        apps.default = flake-utils.lib.mkApp { drv = self.packages.${system}.default; };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            golangci-lint
+            lefthook
+            gotools
+            xclip
+            wl-clipboard
+          ];
+
+          shellHook = ''
+            echo "tele dev shell — go $(go version | cut -d' ' -f3)"
+            echo "  go run ./cmd/tele/ -config .config/tele/config.yml   # run (dev config)"
+            echo "  go test ./...                                        # test"
+            echo "  golangci-lint run ./...                              # lint"
+          '';
+        };
+
+        formatter = pkgs.nixfmt;
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a `flake.nix` exposing `packages.default` (via `buildGoModule`, CGO-free, mirrors the existing `mise run build` task), `apps.default` (`nix run`), and a `devShells.default` mirroring `.mise.toml`'s tooling (go, golangci-lint, lefthook, gotools, plus xclip/wl-clipboard for local clipboard testing).
- `main.buildAPIID`/`main.buildAPIHash`/`main.appName` are intentionally left unset in the flake build (those are release-time secrets/channel flags injected by `.goreleaser.yaml`) — users configure real Telegram credentials via `config.yml`, which `main.go` already supports as a fallback.
- Documents `nix run`, `nix profile install`, and consuming `tele` as a flake input (e.g. from a NixOS configuration) in the README's Installation section.

## Test plan
- [x] `nix flake check` passes
- [x] `nix build .#default` succeeds; `./result/bin/tele -version` prints `1.8.0`
- [x] `nix run .#default -- -version` works
- [x] `nix develop` provides go 1.26.4, golangci-lint, lefthook, gotools as expected