### PR TITLE
fix(ui): include archived chats in custom folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Older releases are at <https://github.com/sorokin-vladimir/tele/releases>.
   update; the edit handler discarded such edits to avoid a false "edited" label
   (#118) and, with them, the reactions they carried. The handler now applies the
   reactions from a hidden edit while still not marking the message edited (#160)
+- Archived chats now appear in custom Telegram folders when the folder rules
+  include them, including category matches such as groups
 
 ## [1.8.0] - 2026-07-06
 

--- a/internal/ui/root_folders.go
+++ b/internal/ui/root_folders.go
@@ -30,10 +30,11 @@ func (m RootModel) filteredChats() []store.Chat {
 		return out
 	}
 
-	// Custom filter: matches and not archived.
+	// Custom filter: FolderFilter.Matches owns Telegram folder rules, including
+	// whether archived chats should be excluded.
 	out := make([]store.Chat, 0, len(all))
 	for _, c := range all {
-		if !c.IsArchived && m.activeFilter.Matches(c) {
+		if m.activeFilter.Matches(c) {
 			out = append(out, c)
 		}
 	}

--- a/internal/ui/root_internal_test.go
+++ b/internal/ui/root_internal_test.go
@@ -90,3 +90,31 @@ func TestFilteredChats_ArchiveSplit(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, int64(2), got[0].ID)
 }
+
+func TestFilteredChats_CustomFolderIncludesArchivedExplicitPeer(t *testing.T) {
+	st := store.NewMemory()
+	st.SetChat(store.Chat{ID: 1, Title: "Normal", Peer: store.Peer{ID: 1, Type: store.PeerUser}})
+	st.SetChat(store.Chat{ID: 2, Title: "Archived", Peer: store.Peer{ID: 2, Type: store.PeerChannel}, IsArchived: true})
+
+	m := NewRootModel(nil, st, 50, false)
+	f := store.FolderFilter{ID: 7, Title: "News", IncludePeers: []int64{2}}
+	m.activeFilter = &f
+
+	got := m.filteredChats()
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(2), got[0].ID)
+}
+
+func TestFilteredChats_CustomFolderIncludesArchivedCategoryMatch(t *testing.T) {
+	st := store.NewMemory()
+	st.SetChat(store.Chat{ID: 1, Title: "Normal", Peer: store.Peer{ID: 1, Type: store.PeerUser}})
+	st.SetChat(store.Chat{ID: 2, Title: "Archived", Peer: store.Peer{ID: 2, Type: store.PeerGroup}, IsArchived: true})
+
+	m := NewRootModel(nil, st, 50, false)
+	f := store.FolderFilter{ID: 7, Title: "Groups", Groups: true}
+	m.activeFilter = &f
+
+	got := m.filteredChats()
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(2), got[0].ID)
+}


### PR DESCRIPTION
## Summary
- Show archived chats in custom Telegram folders when the folder rules include them.
- Keep the existing All Chats and Archive split unchanged.
- Add regression coverage for both explicit `IncludePeers` and category matches such as `Groups: true`.
- Update `CHANGELOG.md` for the user-facing fix.

## Related issue
N/A

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `mise run check` passes locally (vet + lint + tests)
- [x] Added or updated tests for the change
- [x] Updated docs (README / keybindings) where relevant
- [x] Updated `CHANGELOG.md` if the change is user-facing
- [x] Commit messages follow the project convention

## Tests
- `mise run check`
- `go test -race ./...`