### PR TITLE
Fix composer colors after terminal theme switches

### DIFF
--- a/internal/ui/components/composer.go
+++ b/internal/ui/components/composer.go
@@ -503,7 +503,7 @@ func (c *Composer) VisualHeight() int {
 }
 
 func (c *Composer) View() string {
-	c.applyCanvas()
+	c.applyTheme()
 	content := c.buildContent()
 	h := strings.Count(content, "\n") + 1 + 2
 
@@ -521,36 +521,32 @@ func (c *Composer) View() string {
 	return RenderBox(content, "", "", "", c.sendAffordance(), lipgloss.RoundedBorder(), borderFg, c.width, h)
 }
 
-// applyCanvas puts the canvas behind the textarea's own styles.
+// applyTheme refreshes the textarea styles for the active terminal scheme, then
+// puts the optional canvas behind them.
 //
-// The textarea is a vendored component that emits its own cells — the draft
-// text, the placeholder, the prompt inset, the end-of-buffer markers — and none
-// of them go through theme.NewStyle. Left alone it is a hole in the canvas the
-// size of the composer. Only the background is added: what the component chooses
-// to look like otherwise is its own business, and overwriting its defaults here
-// would change the composer's appearance for everyone, canvas or not.
+// textarea.New starts with dark styles and does not observe tele's theme changes.
+// Rebuilding its defaults also clears a canvas from an earlier custom theme.
 //
 // It runs per frame because the theme can change under a running session, and
 // the styles are values rather than a live reference to it.
-func (c *Composer) applyCanvas() {
+func (c *Composer) applyTheme() {
+	s := textarea.DefaultStyles(theme.IsDark())
 	bg := theme.T().Background
-	if theme.IsNone(bg) {
-		return
+	if !theme.IsNone(bg) {
+		paint := func(s textarea.StyleState) textarea.StyleState {
+			s.Base = s.Base.Background(bg)
+			s.Text = s.Text.Background(bg)
+			s.LineNumber = s.LineNumber.Background(bg)
+			s.CursorLineNumber = s.CursorLineNumber.Background(bg)
+			s.CursorLine = s.CursorLine.Background(bg)
+			s.EndOfBuffer = s.EndOfBuffer.Background(bg)
+			s.Placeholder = s.Placeholder.Background(bg)
+			s.Prompt = s.Prompt.Background(bg)
+			return s
+		}
+		s.Focused = paint(s.Focused)
+		s.Blurred = paint(s.Blurred)
 	}
-	paint := func(s textarea.StyleState) textarea.StyleState {
-		s.Base = s.Base.Background(bg)
-		s.Text = s.Text.Background(bg)
-		s.LineNumber = s.LineNumber.Background(bg)
-		s.CursorLineNumber = s.CursorLineNumber.Background(bg)
-		s.CursorLine = s.CursorLine.Background(bg)
-		s.EndOfBuffer = s.EndOfBuffer.Background(bg)
-		s.Placeholder = s.Placeholder.Background(bg)
-		s.Prompt = s.Prompt.Background(bg)
-		return s
-	}
-	s := c.ta.Styles()
-	s.Focused = paint(s.Focused)
-	s.Blurred = paint(s.Blurred)
 	c.ta.SetStyles(s)
 }
 

--- a/internal/ui/components/composer_internal_test.go
+++ b/internal/ui/components/composer_internal_test.go
@@ -1,0 +1,25 @@
+package components
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	"github.com/sorokin-vladimir/tele/internal/ui/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComposer_RefreshesTextareaStylesForThemeChange(t *testing.T) {
+	t.Cleanup(func() { theme.SetSlots(theme.Slots{Dark: theme.TeleDark, Light: theme.TeleLight}) })
+	theme.SetSlots(theme.Slots{Dark: theme.TeleDark, Light: theme.TeleLight})
+
+	c := NewComposer(60)
+	c.Focus()
+
+	theme.Apply(false)
+	c.View()
+	assert.Equal(t, textarea.DefaultLightStyles().Focused.CursorLine.GetBackground(), c.ta.Styles().Focused.CursorLine.GetBackground())
+
+	theme.Apply(true)
+	c.View()
+	assert.Equal(t, textarea.DefaultDarkStyles().Focused.CursorLine.GetBackground(), c.ta.Styles().Focused.CursorLine.GetBackground())
+}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -292,5 +292,8 @@ func currentIsDark() bool {
 // load.
 func T() *Theme { return &current.Load().theme }
 
+// IsDark reports the terminal background classification used for the current theme.
+func IsDark() bool { return currentIsDark() }
+
 // S returns the styles derived from the current theme.
 func S() *Styles { return &current.Load().styles }


### PR DESCRIPTION
Fixes #242.

Rebuild the textarea styles from the current terminal dark/light classification on each composer render, then apply the resolved theme canvas when present. This prevents `textarea.New()` dark defaults from persisting after a light transition and clears a canvas retained from an earlier custom light theme.

Tests:
- `GOMAXPROCS=1 go test -p 1 ./internal/ui/components`
- `GOMAXPROCS=1 go build -p 1 -o /tmp/opencode/tele-theme-fix ./cmd/tele`
- `/tmp/opencode/tele-theme-fix --theme-check`