### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ Beta builds come from prerelease tags (`vX.Y.Z-beta.N`) and are published as
 GitHub prereleases, so they never show up as the "latest" release. Run it with
 `tele-beta`.
 
+### macOS / Linux - X-CMD
+
+[x-cmd](https://www.x-cmd.com/) is a modern Shell toolkit that gives AI agents and developers powerful, portable, and composable command-line capabilities.
+
+```bash
+x eget use sorokin-vladimir/tele
+```
+
 ### Linux - binary
 
 ```sh


### PR DESCRIPTION
<!-- Thanks for contributing to tele! Please fill in the sections below. -->

## Summary

Add `x eget` as an installation method for tele.

`x eget` allows users to install tele directly from its GitHub release:

```bash
x eget use sorokin-vladimir/tele
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [x] Documentation
- [ ] Other

## Checklist

- [ ] `mise run check` passes locally (vet + lint + tests)
- [ ] Added or updated tests for the change
- [ ] Updated docs (README / keybindings) where relevant
- [ ] Updated `CHANGELOG.md` if the change is user-facing
- [ ] Commit messages follow the project convention (`type: #issue Description`)

## Notes for reviewers

<!-- Anything reviewers should pay special attention to: screenshots, trade-offs, follow-ups. -->
